### PR TITLE
Dev hotfix 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { Block, Button, Card, Input, Text } from "./src";
+import { Block, Button, Card, Input, Text } from "./src/index";
 import * as theme from "./src/theme";
 import * as Utils from "./src/utils";
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^25.2.1",
     "@types/react": "^16.9.34",
-    "@types/react-native": "^0.62.2",
+    "@types/react-native": "^0.62.7",
     "@types/react-test-renderer": "^16.9.2",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-native",
     "module": "commonjs"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,13 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "preserve" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
+    "jsx": "react-native" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist" /* Redirect output structure to the directory. */,
-    "rootDir": "./src" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+    "rootDir": "./" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */,
@@ -67,6 +67,6 @@
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["src/**/*"],
+
   "exclude": ["coverage", "dist", "node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -67,6 +67,6 @@
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-
+  "include": ["src/**/*", "index.*"],
   "exclude": ["coverage", "dist", "node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,11 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "ES2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": [
+      "ES2017"
+    ] /* Specify library files to be included in the compilation. */,
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react-native" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
@@ -67,6 +69,6 @@
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["src/**/*", "index.*"],
+  "include": ["src/**/*"],
   "exclude": ["coverage", "dist", "node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,10 +1233,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-native@^0.62.2":
-  version "0.62.2"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.62.2.tgz#f3e150f308c27089cefbcbfa3eb6cc14db279b2f"
-  integrity sha512-oIUIbqZNN9vRnGKWHYbTVp/GyTqdaM5mfy1s4zsi6BYvHAaFOPZ32IrhIHno/A5XOv4wuGfE7g5fliDk/H0+/Q==
+"@types/react-native@^0.62.7":
+  version "0.62.7"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.62.7.tgz#bfc5ed03ba576f288603daa3f67f0f67d9a8bf57"
+  integrity sha512-FGFEt9GcFVl//XxWmxkeBxAx0YnzyEhJpR8hOJrjfaFKZm0KjHzzyCmCksBAP2qHSTrcJCiBkIvYCX/kGiOgww==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
I didn't find out anything related to issues with shebang using react.
So it is not common unless is a new problem, but I doubt that.

What I found is a similar error but with ts-loader [reference](https://stackoverflow.com/questions/56845547/tsloader-babel-polyfill-you-may-need-an-additional-loader-to-handle-the-resu).
I don't know if this is going to work as the #61 does not occur on my console, just on bundlephobia. (or was hidden among the conflict errors).(which is clean now)
But makes sense cause as it is not recognizing JSX syntax.

- [x] And this resolved sucessfully react-native conflict with dom types. [answer](https://stackoverflow.com/a/53287649/12669100)